### PR TITLE
Enhance Link Creation with Filtered Resource Index Support

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -10,6 +10,8 @@ use JsonSerializable;
 use Laravel\Nova\AuthorizedToSee;
 use Laravel\Nova\Lenses\Lens;
 use Laravel\Nova\Makeable;
+use Laravel\Nova\Nova;
+use Laravel\Nova\Filters\FilterEncoder;
 
 /**
  * @method static static make(string $label)
@@ -43,23 +45,20 @@ class Link implements JsonSerializable
      *
      * @param class-string<BaseNovaResource> $resource
      * @param class-string<Filter> $filterClass
-     * @param ?string $label
+     * @param string $label
      * @return self
      */
-    public static function toFilteredResourceIndex(string $resource, string $filterClass, int $value, string $filterParamName = 'filters', ?string $label = null): self
+    public static function toFilteredResourceIndex(string $resource, string $filterClass, int $value, string $label): self
     {
-        $filters = [
+        $filters = new FilterEncoder([
             [
-                'class' => $filterClass,
-                'value' => $value,
+                $filterClass => $value,
             ],
-        ];
+        ]);
 
-        $encodedFilters = base64_encode(json_encode($filters));
+        $url = Nova::path() . '/resources/' . $resource::uriKey() . '?' . $resource::uriKey(). '_filter' . '=' . $filters->encode();
 
-        $url = Nova::path() . '/resources/' . $resource::uriKey() . '?' . $filterParamName . '=' . $encodedFilters;
-
-        return static::make($label ?: 'Filtered ' . $resource::label())
+        return static::make($label)
             ->url($url, false)
             ->openInNewTab(false);
     }

--- a/src/Link.php
+++ b/src/Link.php
@@ -39,6 +39,32 @@ class Link implements JsonSerializable
     }
 
     /**
+     * Creates a link to a Nova resource index with filters applied.
+     *
+     * @param class-string<BaseNovaResource> $resource
+     * @param class-string<Filter> $filterClass
+     * @param ?string $label
+     * @return self
+     */
+    public static function toFilteredResourceIndex(string $resource, string $filterClass, int $value, string $filterParamName = 'filters', ?string $label = null): self
+    {
+        $filters = [
+            [
+                'class' => $filterClass,
+                'value' => $value,
+            ],
+        ];
+
+        $encodedFilters = base64_encode(json_encode($filters));
+
+        $url = Nova::path() . '/resources/' . $resource::uriKey() . '?' . $filterParamName . '=' . $encodedFilters;
+
+        return static::make($label ?: 'Filtered ' . $resource::label())
+            ->url($url, false)
+            ->openInNewTab(false);
+    }
+
+    /**
      * @param class-string<BaseNovaResource> $resource
      */
     public static function toResourceCreate(string $resource, ?string $label = null): self

--- a/src/NovaResource.php
+++ b/src/NovaResource.php
@@ -11,7 +11,7 @@ use Laravel\Nova\Nova;
 
 class NovaResource extends Link
 {
-    private string $resourceUriKey;
+    protected string $resourceUriKey;
 
     /**
      * @param class-string<BaseNovaResource> $resource


### PR DESCRIPTION
Summary:
This pull request introduces enhancements to the Link class, adding the ability to create links to Nova resource indexes with filters applied directly from the URL. This feature leverages Nova's existing filtering capabilities to provide a more dynamic and user-friendly navigation experience within the Nova dashboard.

Changes:
Added Laravel\Nova\Nova and Laravel\Nova\Filters\FilterEncoder to the Link class for enhanced filtering support.
Implemented a new method toFilteredResourceIndex within the Link class. This method allows for the creation of links that navigate to a filtered view of a Nova resource index, based on specified filter criteria.
The toFilteredResourceIndex method utilizes the FilterEncoder to encode filter parameters, ensuring compatibility with Nova's expected URL structure for filtered views.
Benefits:
Dynamic Filtering: Allows users to create navigation links that lead directly to pre-filtered resource indexes, improving the navigability and usability of the Nova dashboard.
Enhanced Customization: Developers can now easily add links to their Nova resources or tools that include specific filters, tailoring the dashboard experience to meet user needs more closely.
Consistency with Nova: By using Nova's own FilterEncoder, this implementation ensures compatibility and maintains a consistent approach to handling filters within the Nova ecosystem.
Use Cases:
Dashboard customization where direct links to specific filtered views of resources are needed.
Enhancing Nova tools or custom cards with links that lead to relevant, pre-filtered data, improving the workflow efficiency for users.
I believe these enhancements will significantly benefit the Nova community by providing a more flexible and user-friendly way to navigate between filtered views of resources. I look forward to your feedback and any further suggestions for improvement.